### PR TITLE
Mention Python 3.11 support in trove classifiers.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,20 +28,20 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
-        - ["3.11.0-rc.2",  "py311"]
+        - ["3.11",  "py311"]
         - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,14 +2,14 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "54e37f7de7149c0d4003e40bbe300d012a851ce7"
+commit-id = "9e96d80474deebd9f4a001b60c7da2682d925cdd"
 
 [python]
 with-pypy = false
 with-legacy-python = true
 with-sphinx-doctests = false
 with-windows = false
-with-future-python = true
+with-future-python = false
 
 [tox]
 use-flake8 = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.7 (unreleased)
 ----------------
 
+- Mention Python 3.11 support in trove classifiers.
+
 
 1.6 (2022-10-18)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     keywords='zope request global',

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = py311: true
 deps =
 commands =
     zope-testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
This fixes the GHA lint job.