### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.1 (2025-09-04)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '2.2.dev0'
+version = '3.0.dev0'
 
 readme = open('README.rst').read()
 changes = open('CHANGES.rst').read()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -42,9 +41,6 @@ setup(
         'Sources': 'https://github.com/zopefoundation/zope.globalrequest',
     },
     license='ZPL',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     include_package_data=True,
     platforms='Any',
     zip_safe=False,
@@ -56,6 +52,6 @@ setup(
         'zope.traversing',
     ],
     extras_require=dict(
-        test=['zope.testrunner'],
+        test=['zope.testrunner >= 6.4'],
     ),
 )

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
